### PR TITLE
Add support for version prefixes in NewVersion and related methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ The library also supports parsing versions with a custom prefix.
 Using the `WithPrefix` option, you can specify a prefix to strip
 before parsing the version.
 
+Use `WithPrefix` when your input strings carry a known release prefix such as
+`deployment-`, `controller-`, etc.
+
+After parsing, the prefix is not part of the canonical version value. This
+means the regular comparison methods such as `Compare`, `LessThan`, `Equal`,
+and `GreaterThan` compare only the stripped version. If you compare versions
+from different prefixes with these methods, the prefixes are ignored. If you
+need to reject cross-prefix comparisons, inspect the parsed prefixes before
+comparing the versions.
+
 ```go
 v1, _ := version.NewVersion("deployment-v1.2.3-beta+metadata", version.WithPrefix("deployment-"))
 v2, _ := version.NewVersion("deployment-v1.2.4", version.WithPrefix("deployment-"))

--- a/version.go
+++ b/version.go
@@ -73,10 +73,13 @@ type Version struct {
 	segments []int64
 	si       int
 	original string
+	prefix   string
 }
 
-// NewVersion parses the given version and returns a new
-// Version.
+// NewVersion parses the given version and returns a new Version.
+//
+// Optional parsing behavior can be enabled with Option values such as
+// WithPrefix, which validates and strips an expected prefix before parsing.
 func NewVersion(v string, opts ...Option) (*Version, error) {
 	options := &options{}
 	for _, opt := range opts {
@@ -97,6 +100,7 @@ func NewVersion(v string, opts ...Option) (*Version, error) {
 	if err != nil {
 		return nil, err
 	}
+	ver.prefix = options.prefix
 	ver.original = v
 	return ver, nil
 }
@@ -459,6 +463,11 @@ func (v *Version) bytes() []byte {
 // potential whitespace, `v` prefix, etc.
 func (v *Version) Original() string {
 	return v.original
+}
+
+// Prefix returns the explicit prefix used with WithPrefix, if any.
+func (v *Version) Prefix() string {
+	return v.prefix
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler interface.

--- a/version_test.go
+++ b/version_test.go
@@ -178,12 +178,6 @@ func TestVersionCompare(t *testing.T) {
 		{"1.7rc2", "1.7rc1", 1},
 		{"1.7rc2", "1.7", -1},
 		{"1.2.0", "1.2.0-X-1.2.0+metadata~dist", 1},
-		{"controller-v0.40.2", "controller-v0.40.3", -1},
-		{"0.40.4", "controller-v0.40.2", 1},
-		{"0.40.4", "controller-v0.40.4", 0},
-		{"azure-cli-v1.4.2", "azure-cli-v1.4.2", 0},
-		{"azure-cli-v1.4.1", "azure-cli-v1.4.2", -1},
-		{"1.4.3", "azure-cli-v1.4.2", 1},
 	}
 
 	for _, tc := range cases {
@@ -205,6 +199,107 @@ func TestVersionCompare(t *testing.T) {
 				tc.v1, tc.v2,
 				expected, actual)
 		}
+	}
+}
+
+func TestVersionCompareWithPrefix(t *testing.T) {
+	cases := []struct {
+		v1       string
+		v1Prefix string
+		v2       string
+		v2Prefix string
+		expected int
+	}{
+		{"controller-v0.40.2", "controller-", "controller-v0.40.3", "controller-", -1},
+		{"0.40.4", "", "controller-v0.40.2", "controller-", 1},
+		{"0.40.4", "", "controller-v0.40.4", "controller-", 0},
+		{"azure-cli-v1.4.2", "azure-cli-", "azure-cli-v1.4.2", "azure-cli-", 0},
+		{"azure-cli-v1.4.1", "azure-cli-", "azure-cli-v1.4.2", "azure-cli-", -1},
+		{"1.4.3", "", "azure-cli-v1.4.2", "azure-cli-", 1},
+		{"v1.4.3", "", "azure-cli-v1.4.2", "azure-cli-", 1},
+		{"controller-v1.4.1", "controller-", "azure-cli-v1.4.2", "azure-cli-", -1},
+	}
+
+	for _, tc := range cases {
+		var v1 *Version
+		var err error
+		if tc.v1Prefix != "" {
+			v1, err = NewVersion(tc.v1, WithPrefix(tc.v1Prefix))
+		} else {
+			v1, err = NewVersion(tc.v1)
+		}
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		var v2 *Version
+		if tc.v2Prefix != "" {
+			v2, err = NewVersion(tc.v2, WithPrefix(tc.v2Prefix))
+		} else {
+			v2, err = NewVersion(tc.v2)
+		}
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		actual := v1.Compare(v2)
+		expected := tc.expected
+		if actual != expected {
+			t.Fatalf(
+				"%s <=> %s\nexpected: %d\nactual: %d",
+				tc.v1, tc.v2,
+				expected, actual)
+		}
+	}
+}
+
+func TestVersionAccessorsWithPrefix(t *testing.T) {
+	v, err := NewVersion("controller-v1.2.0-beta.2+build.5", WithPrefix("controller-"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if got := v.Prefix(); got != "controller-" {
+		t.Fatalf("expected prefix %q, got %q", "controller-", got)
+	}
+
+	if got := v.Original(); got != "controller-v1.2.0-beta.2+build.5" {
+		t.Fatalf("expected original %q, got %q", "controller-v1.2.0-beta.2+build.5", got)
+	}
+
+	if got := v.String(); got != "1.2.0-beta.2+build.5" {
+		t.Fatalf("expected string %q, got %q", "1.2.0-beta.2+build.5", got)
+	}
+
+	if got := v.Metadata(); got != "build.5" {
+		t.Fatalf("expected metadata %q, got %q", "build.5", got)
+	}
+
+	if got := v.Prerelease(); got != "beta.2" {
+		t.Fatalf("expected prerelease %q, got %q", "beta.2", got)
+	}
+
+	expectedSegments := []int{1, 2, 0}
+	if got := v.Segments(); !reflect.DeepEqual(got, expectedSegments) {
+		t.Fatalf("expected segments %#v, got %#v", expectedSegments, got)
+	}
+
+	expectedSegments64 := []int64{1, 2, 0}
+	if got := v.Segments64(); !reflect.DeepEqual(got, expectedSegments64) {
+		t.Fatalf("expected segments64 %#v, got %#v", expectedSegments64, got)
+	}
+}
+
+func TestVersionSegmentsWithPrefix(t *testing.T) {
+	v, err := NewVersion("azure-cli-v1.4.2", WithPrefix("azure-cli-"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := []int{1, 4, 2}
+	actual := v.Segments()
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("expected: %#v\nactual: %#v", expected, actual)
 	}
 }
 


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description
- It would make sense to have prefix as one of the attributes of version as the information may get lost when operations like `Compare`, `GreaterThan`, etc. strip the prefix to compare versions.
- Added more context in readme to guide the users on this new feature.
- Added some more prefix related unit tests which demonstrate what output to expect.
<!-- Provide a summary of what the PR does and why it is being submitted. -->

## Related Issue
https://github.com/hashicorp/go-version/pull/79
<!-- If this PR is linked to any issue, provide the issue number or description here. Any related JIRA tickets can also be added here. -->

## How Has This Been Tested?
`go test ./...`
<!-- Describe how the changes have been tested. Provide test instructions or details. -->
